### PR TITLE
Fix docker compose race condition

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,3 +37,5 @@ services:
       - "4002:4000"
     volumes:
       - ./:/app
+    depends_on:
+      - user


### PR DESCRIPTION
Add depends_on option to parcel service to enforce services startup order to prevent race condition.
![image](https://user-images.githubusercontent.com/46595454/193416935-15375ba9-c09d-40c8-9a66-d54060a61261.png)
